### PR TITLE
Require the que gem to fix version check

### DIFF
--- a/bin/que
+++ b/bin/que
@@ -26,6 +26,7 @@ OptionParser.new do |opts|
   end
 
   opts.on('-v', '--version', "Show Que version") do
+    require 'que'
     $stdout.puts "Que version #{Version}"
     exit 0
   end


### PR DESCRIPTION
The que gem is not loaded when you just want to check the version.
